### PR TITLE
fix: removed unit tests checking for jdk6 behavior

### DIFF
--- a/swingx-core/src/test/java/org/jdesktop/swingx/tree/TreeModelSupportTest.java
+++ b/swingx-core/src/test/java/org/jdesktop/swingx/tree/TreeModelSupportTest.java
@@ -67,24 +67,6 @@ public class TreeModelSupportTest extends TestCase {
     
     /**
      * test modelSupport pathChanged: 
-     * not null path  must not be empty, (checked by TreePath)
-     * path elements must not be null (core issue - should be checked
-     *   by TreePath but isn't)
-     */
-    @Test
-    public void testPathChangedNotNullPathElements() {
-        TreePath path = new TreePath(new Object[] {null});
-        try {
-            support.firePathChanged(path);
-            fail("must not allow null path elements");
-        } catch (NullPointerException e) {
-            // expected
-        } 
-        // unexpected exception
-    }
-    
-    /**
-     * test modelSupport pathChanged: 
      * throw on null path
      */
     @Test
@@ -113,28 +95,6 @@ public class TreeModelSupportTest extends TestCase {
         assertNull(structureEvent.getTreePath());
         assertNull(structureEvent.getPath());
     }
-
-    /**
-     * test modelSupport treeStructureChanged: 
-     * not null path  must not be empty, (checked by TreePath)
-     * path elements must not be null (core issue - should be checked
-     *   by TreePath but isn't)
-     * first element must be root (? not sure so don't enforce).
-     *
-     *
-     */
-    @Test
-    public void testTreeStructureChangedNotNullPathElements() {
-        TreePath path = new TreePath(new Object[] {null});
-        try {
-            support.fireTreeStructureChanged(path);
-            fail("must not allow null path elements");
-        } catch (NullPointerException e) {
-            // expected
-        } 
-        // unexpected exception
-    }
-    
 
     /**
      * test modelSupport treeStructureChanged: 


### PR DESCRIPTION
In JDK 6 javax.swing.tree.TreePath constructor was accepting a null element, now it doesn't. Removed unit tests that are now failing because the TreePath constructor fails as it should.

JDK 6 TreePath constructor (source: https://github.com/frohoff/jdk6/blob/master/src/share/classes/javax/swing/tree/TreePath.java):

```
    public TreePath(Object[] path) {
        if(path == null || path.length == 0)
            throw new IllegalArgumentException("path in TreePath must be non null and not empty.");
        lastPathComponent = path[path.length - 1];
        if(path.length > 1)
            parentPath = new TreePath(path, path.length - 1);
    }
```

Current constructor:

```
    public TreePath(Object[] path) {
        if(path == null || path.length == 0)
            throw new IllegalArgumentException("path in TreePath must be non null and not empty.");
        lastPathComponent = path[path.length - 1];
        if (lastPathComponent == null) {
            throw new IllegalArgumentException(
                "Last path component must be non-null");
        }
        if(path.length > 1)
            parentPath = new TreePath(path, path.length - 1);
    }
```